### PR TITLE
add verified property to FlowTaskTemplateEntity, crud updates

### DIFF
--- a/src/main/java/net/boomerangplatform/mongo/entity/FlowTaskTemplateEntity.java
+++ b/src/main/java/net/boomerangplatform/mongo/entity/FlowTaskTemplateEntity.java
@@ -28,6 +28,7 @@ public class FlowTaskTemplateEntity {
   private FlowTaskTemplateStatus status;
   private Date createdDate;
   private String icon;
+  private boolean verified;
 
   public FlowTaskTemplateEntity() {
     // Do nothing
@@ -111,6 +112,14 @@ public class FlowTaskTemplateEntity {
 
   public void setIcon(String icon) {
     this.icon = icon;
+  }
+
+  public boolean isVerified() {
+    return verified;
+  }
+
+  public void setVerified(boolean verified) {
+    this.verified = verified;
   }
 
 }

--- a/src/main/java/net/boomerangplatform/service/crud/TaskTemplateServiceImpl.java
+++ b/src/main/java/net/boomerangplatform/service/crud/TaskTemplateServiceImpl.java
@@ -68,6 +68,7 @@ public class TaskTemplateServiceImpl implements TaskTemplateService {
 
     flowTaskTemplateEntity.setCreatedDate(creationDate);
     flowTaskTemplateEntity.setLastModified(creationDate);
+    flowTaskTemplateEntity.setVerified(false);
 
     updateChangeLog(flowTaskTemplateEntity);
 
@@ -79,6 +80,7 @@ public class TaskTemplateServiceImpl implements TaskTemplateService {
     updateChangeLog(flowTaskTemplateEntity);
 
     flowTaskTemplateEntity.setLastModified(new Date());
+    flowTaskTemplateEntity.setVerified(false);
     return new FlowTaskTemplate(flowTaskTemplateService.updateTaskTemplate(flowTaskTemplateEntity));
   }
 

--- a/src/test/java/net/boomerangplatform/tests/controller/TaskTemplateControllerTests.java
+++ b/src/test/java/net/boomerangplatform/tests/controller/TaskTemplateControllerTests.java
@@ -38,6 +38,7 @@ public class TaskTemplateControllerTests extends FlowTests {
     FlowTaskTemplate template = controller.getTaskTemplateWithId("5bd9d0825a5df954ad5bb5c3");
     assertEquals("5bd9d0825a5df954ad5bb5c3", template.getId());
     assertEquals(1, template.getCurrentVersion());
+    assertEquals(false, template.isVerified());
 
   }
 
@@ -46,6 +47,7 @@ public class TaskTemplateControllerTests extends FlowTests {
     List<FlowTaskTemplate> templates = controller.getAllTaskTemplates();
     assertEquals(9, templates.size());
     assertEquals(1, templates.get(0).getCurrentVersion());
+    assertEquals(false, templates.get(0).isVerified());
 
   }
 
@@ -58,6 +60,7 @@ public class TaskTemplateControllerTests extends FlowTests {
     entity.setNodeType("custom");
     FlowTaskTemplate testTemplate = controller.insertTaskTemplate(entity);
     assertEquals("TestTaskTemplate", testTemplate.getName());
+    assertEquals(false, testTemplate.isVerified());
 
   }
 
@@ -69,6 +72,7 @@ public class TaskTemplateControllerTests extends FlowTests {
     entity.setDescription("test");
 
     entity.setName("TestTaskTemplate");
+    entity.setVerified(true);
 
     Revision revision = new Revision();
     ChangeLog changelog = new ChangeLog();
@@ -90,6 +94,7 @@ public class TaskTemplateControllerTests extends FlowTests {
 
     assertNotNull(updatedEntity.getRevisions().get(0).getChangelog().getUserId());
     assertEquals("reason", updatedEntity.getRevisions().get(0).getChangelog().getReason());
+    assertEquals(false, updatedEntity.isVerified());
   }
 
   @Test


### PR DESCRIPTION
Closes #

PLT-4610

#### Changelog

**New**

- Added boolean verified to FlowTaskTemplateEntity

**Changed**

- Updated FlowTaskTemplate creation to default boolean verified to false, prevented boolean verified from being changed from false when updating FlowTaskTemplate

**Removed**

- None

#### Testing / Reviewing

Unit tests updated to reflect expected behavior
