### PR TITLE
Return 403 status on validate token

### DIFF
--- a/src/main/java/net/boomerangplatform/service/crud/WorkflowServiceImpl.java
+++ b/src/main/java/net/boomerangplatform/service/crud/WorkflowServiceImpl.java
@@ -412,7 +412,7 @@ public class WorkflowServiceImpl implements WorkflowService {
     if (workflowToken != null) {
       return ResponseEntity.ok(HttpStatus.OK);
     }
-    return ResponseEntity.ok(HttpStatus.FORBIDDEN);
+    return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
   }
 
   private static final char[] hexArray = "0123456789ABCDEF".toCharArray();


### PR DESCRIPTION
#### Changelog

**New**

- {{new thing}}

**Changed**

- Fixes the return on /internal/tokenValidation to status of 403 instead for 200 with FORBIDDEN in the body
- 
**Removed**

- {{removed thing}}

#### Testing / Reviewing

Validated locally and in DEV
