### PR TITLE
`NullPointerException` fix when unsubscribing from eventing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
 		<dependency>
 			<groupId>io.boomerang</groupId>
 			<artifactId>lib-eventing</artifactId>
-			<version>0.2.2</version>
+			<version>0.2.4</version>
 		</dependency>
 		<dependency>
 			<groupId>io.boomerang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
 		<dependency>
 			<groupId>io.boomerang</groupId>
 			<artifactId>lib-eventing</artifactId>
-			<version>0.2.4</version>
+			<version>0.2.5</version>
 		</dependency>
 		<dependency>
 			<groupId>io.boomerang</groupId>

--- a/src/main/java/io/boomerang/client/EventingSubscriberClient.java
+++ b/src/main/java/io/boomerang/client/EventingSubscriberClient.java
@@ -95,11 +95,12 @@ public class EventingSubscriberClient {
       @Override
       public void subscriptionFailed(PubSubTunnel tunnel, Exception exception) {
         logger.debug(
-            "Failed to subscribe for consuming messages from NATS Jetstream. Resubscribing...");
+            "Failed to subscribe for consuming messages from NATS Jetstream. Resubscribing...",
+            exception);
         try {
           Thread.sleep(jetstreamConsumerResubscribeWaitTime.toMillis());
         } catch (Exception e) {
-          logger.warn("Sleep failed: resubscribing without a waiting time...");
+          logger.warn("Sleep failed: resubscribing without a waiting time...", e);
         } finally {
           startSubscription(tunnel);
         }


### PR DESCRIPTION
#### Fixes `NullPointerException` when unsubscribing from eventing.

When the service starts and fails to subscribe to Jetstream for listening to new messages (due to connection issues to the NATS server), a back-up mechanism automatically disables the active subscription and will create a new one once the connection to the NATS server is established. This PR fixes the bug which prevented to continue service execution due to a `NullPointerException` error that was thrown when this mechanism takes over.

#### Changelog

**New**

- `lib.eventing` upgraded to `0.2.6`

**Changed**

-  Additional logging
