### PR TITLE
Adjusted logging levels and moved to chart for certain DEBUG levels

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -143,10 +143,17 @@ springdoc.swagger-ui.enabled=true
 # Spring Logging
 logging.level.net.boomwerangplatform.service.refactor=INFO
 logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=DEBUG
+<<<<<<< Updated upstream
 logging.level.org.springframework.data.mongodb.core.MongoTemplate=DEBUG
 logging.level.net.boomerangplatform.service.runner.misc=DEBUG
 logging.level.net.boomerangplatform.service.crud=DEBUG
 logging.level.net.boomerangplatform.service=DEBUG
+=======
+#logging.level.org.springframework.data.mongodb.core.MongoTemplate=DEBUG
+#logging.level.net.boomerangplatform.service.runner.misc=DEBUG
+#logging.level.net.boomerangplatform.service.crud=DEBUG
+#logging.level.net.boomerangplatform.service=DEBUG
+>>>>>>> Stashed changes
 
 # Misc Spring Configuration
 spring.aop.proxy-target-class=true


### PR DESCRIPTION
Closes https://github.com/boomerang-io/roadmap/issues/332

#### Changelog

**Changed**

- Commented out DEBUG logging levels so they are not used by default. And moved them to the helm chart for when DEBUG is enabled.
