### PR TITLE
fix: User save was saving the request object not the newly created user

### DIFF
--- a/src/main/java/io/boomerang/service/UserIdentityServiceImpl.java
+++ b/src/main/java/io/boomerang/service/UserIdentityServiceImpl.java
@@ -54,7 +54,6 @@ public class UserIdentityServiceImpl implements UserIdentityService {
   @Autowired
   private WorkflowService workflowService;
 
-
   @Autowired
   private TeamService flowTeamService;
 
@@ -224,7 +223,7 @@ public class UserIdentityServiceImpl implements UserIdentityService {
       FlowUserEntity flowUserEntity = flowUserService.getOrRegisterUser(email, name, type);
       flowUserEntity.setQuotas(flowUser.getQuotas());
       flowUserEntity.setHasConsented(true);
-      flowUserEntity = flowUserService.save(flowUser);
+      flowUserEntity = flowUserService.save(flowUserEntity);
 
       FlowUser newUser = new FlowUser();
       BeanUtils.copyProperties(flowUserEntity, newUser);


### PR DESCRIPTION
Closes [#340](https://github.com/boomerang-io/roadmap/issues/340)

Fixes the duplicate create of a user entity. 

#### Changelog

**Changed**

- Upon creation of the user, the entity was updated to include quotas, and then not saved correctly. Updated to save the updated user entity.

#### Testing / Reviewing

Tested in a Flowabl.io dev instance
