### PR TITLE
Set the OwnerUserId when the workflow is newly imported

### DIFF
--- a/src/main/java/io/boomerang/service/crud/WorkflowServiceImpl.java
+++ b/src/main/java/io/boomerang/service/crud/WorkflowServiceImpl.java
@@ -515,14 +515,7 @@ public class WorkflowServiceImpl implements WorkflowService {
           entity.setFlowTeamId(null);
         }
 
-        if (WorkflowScope.user.equals(scope)) {
-          FlowUserEntity user = userIdentityService.getCurrentUser();
-          if (user != null) {
-            entity.setOwnerUserId(user.getId());
-          }
-        } else {
-          entity.setOwnerUserId(null);
-        }
+        setOwnerUser(entity, scope);
 
         WorkflowEntity workflow = workflowRepository.saveWorkflow(entity);
 
@@ -546,14 +539,7 @@ public class WorkflowServiceImpl implements WorkflowService {
           }
         } else {
           newEntity.setFlowTeamId(null);
-          if (WorkflowScope.user.equals(scope)) {
-            FlowUserEntity user = userIdentityService.getCurrentUser();
-            if (user != null) {
-              newEntity.setOwnerUserId(user.getId());
-            }
-          } else {
-            newEntity.setOwnerUserId(null);
-          }
+          setOwnerUser(newEntity, scope);
         }
 
         newEntity.setName(export.getName());
@@ -576,6 +562,17 @@ public class WorkflowServiceImpl implements WorkflowService {
       String message = "Workflow not imported - template(s) not found";
       logger.info(message);
       throw new BoomerangException(BoomerangError.IMPORT_WORKFLOW_FAILED);
+    }
+  }
+
+  private void setOwnerUser(WorkflowEntity entity, WorkflowScope scope) {
+    if (WorkflowScope.user.equals(scope)) {
+      FlowUserEntity user = userIdentityService.getCurrentUser();
+      if (user != null) {
+        entity.setOwnerUserId(user.getId());
+      }
+    } else {
+      entity.setOwnerUserId(null);
     }
   }
 

--- a/src/main/java/io/boomerang/service/crud/WorkflowServiceImpl.java
+++ b/src/main/java/io/boomerang/service/crud/WorkflowServiceImpl.java
@@ -546,6 +546,14 @@ public class WorkflowServiceImpl implements WorkflowService {
           }
         } else {
           newEntity.setFlowTeamId(null);
+          if (WorkflowScope.user.equals(scope)) {
+            FlowUserEntity user = userIdentityService.getCurrentUser();
+            if (user != null) {
+              newEntity.setOwnerUserId(user.getId());
+            }
+          } else {
+            newEntity.setOwnerUserId(null);
+          }
         }
 
         newEntity.setName(export.getName());


### PR DESCRIPTION
Closes [Issue 351](https://github.com/boomerang-io/roadmap/issues/351)

Setting up the `OwnerUserId` when the imported workflow is not already existing in the system (so not an update but rather creating a new workflow).

#### Changelog

**New**

- NA

**Changed**

- Setting up the OwnerUserId

**Removed**

- NA

#### Testing / Reviewing

