### PR TITLE
fix team return

### DIFF
--- a/src/main/java/io/boomerang/service/UserIdentityServiceImpl.java
+++ b/src/main/java/io/boomerang/service/UserIdentityServiceImpl.java
@@ -72,7 +72,6 @@ public class UserIdentityServiceImpl implements UserIdentityService {
         return null;
       }
       BeanUtils.copyProperties(userProfile, flowUser);
-      flowUser.setTeams(null);
 
       String email = userProfile.getEmail();
       FlowUserEntity dbUser = flowUserService.getUserWithEmail(email);


### PR DESCRIPTION
Closes #

For users with platform role of `user`, PATCH /workflow/workflow/{workflowId}/properties returns a 403 due to the teams being set to `null`. 

#### Changelog

**New**

- N/A

**Changed**

- N/A

**Removed**

- Removing ` flowUser.setTeams(null);` from iUserIdentityServiceImpl.getCurrentUser()

#### Testing / Reviewing

Tested and verified locally.
