### PR TITLE
Fixed retrieval of internal Flow teams to be by Id and not HLG

### DIFF
--- a/src/main/java/io/boomerang/mongo/repository/FlowTeamRepository.java
+++ b/src/main/java/io/boomerang/mongo/repository/FlowTeamRepository.java
@@ -16,4 +16,6 @@ public interface FlowTeamRepository extends MongoRepository<TeamEntity, String> 
   Optional<TeamEntity> findById(String id);
 
   Page<TeamEntity> findByIsActive(Pageable pageable, boolean b);
+
+  List<TeamEntity> findByIdInAndIsActive(List<String> ids, Boolean isActive);
 }

--- a/src/main/java/io/boomerang/mongo/service/FlowTeamService.java
+++ b/src/main/java/io/boomerang/mongo/service/FlowTeamService.java
@@ -17,4 +17,6 @@ public interface FlowTeamService {
 
   TeamEntity findById(String id);
 
+  List<TeamEntity> findActiveTeamsByIds(List<String> ids);
+
 }

--- a/src/main/java/io/boomerang/mongo/service/FlowTeamService.java
+++ b/src/main/java/io/boomerang/mongo/service/FlowTeamService.java
@@ -11,8 +11,6 @@ public interface FlowTeamService {
   
   Page<TeamEntity> findAllActiveTeams(Pageable pageable);
 
-  List<TeamEntity> findTeamsWithHighLevelGroups(List<String> highLevelGroups);
-
   TeamEntity save(TeamEntity entity);
 
   TeamEntity findById(String id);

--- a/src/main/java/io/boomerang/mongo/service/FlowTeamServiceImpl.java
+++ b/src/main/java/io/boomerang/mongo/service/FlowTeamServiceImpl.java
@@ -25,11 +25,6 @@ public class FlowTeamServiceImpl implements FlowTeamService {
   }
 
   @Override
-  public List<TeamEntity> findTeamsWithHighLevelGroups(List<String> highLevelGroups) {
-    return flowTeamRepository.findByhigherLevelGroupIdIn(highLevelGroups);
-  }
-
-  @Override
   public List<TeamEntity> findActiveTeamsByIds(List<String> ids) {
     return flowTeamRepository.findByIdInAndIsActive(ids, true);
   }

--- a/src/main/java/io/boomerang/mongo/service/FlowTeamServiceImpl.java
+++ b/src/main/java/io/boomerang/mongo/service/FlowTeamServiceImpl.java
@@ -30,6 +30,11 @@ public class FlowTeamServiceImpl implements FlowTeamService {
   }
 
   @Override
+  public List<TeamEntity> findActiveTeamsByIds(List<String> ids) {
+    return flowTeamRepository.findByIdInAndIsActive(ids, true);
+  }
+
+  @Override
   public TeamEntity save(TeamEntity entity) {
     return flowTeamRepository.save(entity);
   }

--- a/src/main/java/io/boomerang/service/crud/TeamServiceImpl.java
+++ b/src/main/java/io/boomerang/service/crud/TeamServiceImpl.java
@@ -468,14 +468,14 @@ public class TeamServiceImpl implements TeamService {
 
   @Override
   public List<TeamEntity> getUsersTeamListing(FlowUserEntity userEntity) {
-    List<String> highLevelGroupIds = new LinkedList<>();
+    List<String> teamIds = new LinkedList<>();
     if (flowExternalUrlUser.isBlank()) {
-      highLevelGroupIds = userEntity.getFlowTeams();
+      teamIds = userEntity.getFlowTeams();
     } else {
       UserProfile profile = boomerangUserService.getInternalUserProfile();
       List<Team> teams = profile.getTeams();
       if (teams != null) {
-        highLevelGroupIds = teams.stream().map(Team::getId).collect(Collectors.toList());
+        teamIds = teams.stream().map(Team::getId).collect(Collectors.toList());
       }
     }
 
@@ -483,7 +483,7 @@ public class TeamServiceImpl implements TeamService {
     if (!flowExternalUrlTeam.isBlank()) {
       flowTeam = this.externalTeamService.getExternalTeams(flowExternalUrlTeam);
     } else {
-      flowTeam = flowTeamService.findTeamsWithHighLevelGroups(highLevelGroupIds);
+      flowTeam = flowTeamService.findActiveTeamsByIds(teamIds);
     }
     return flowTeam;
   }


### PR DESCRIPTION
Closes #https://github.com/boomerang-io/roadmap/issues/359

Fix the retrieval of internal teams via Id and whether the team isActive

#### Changelog

**New**

- New DB repository method for retrieve teams by ID list and whether active

**Changed**

- Updated specific team retrieval code logic to use new method instead of retrieving by HLG

**Removed**

- The old DB repository method as no longer needed.

#### Testing / Reviewing

Verified with tag `2.4.67-fix.1`
