### PR TITLE
fix retrieve teams by HLG when externalUserUrl is configured

### DIFF
--- a/src/main/java/io/boomerang/mongo/service/FlowTeamService.java
+++ b/src/main/java/io/boomerang/mongo/service/FlowTeamService.java
@@ -16,5 +16,7 @@ public interface FlowTeamService {
   TeamEntity findById(String id);
 
   List<TeamEntity> findActiveTeamsByIds(List<String> ids);
+  
+  List<TeamEntity> findTeamsByHigherLevelGroupIds(List<String> highLevelGroupIds);
 
 }

--- a/src/main/java/io/boomerang/mongo/service/FlowTeamServiceImpl.java
+++ b/src/main/java/io/boomerang/mongo/service/FlowTeamServiceImpl.java
@@ -28,6 +28,11 @@ public class FlowTeamServiceImpl implements FlowTeamService {
   public List<TeamEntity> findActiveTeamsByIds(List<String> ids) {
     return flowTeamRepository.findByIdInAndIsActive(ids, true);
   }
+  
+  @Override
+  public List<TeamEntity> findTeamsByHigherLevelGroupIds(List<String> higherLevelGroupIds) {
+    return flowTeamRepository.findByhigherLevelGroupIdIn(higherLevelGroupIds);
+  }
 
   @Override
   public TeamEntity save(TeamEntity entity) {

--- a/src/main/java/io/boomerang/service/crud/TeamServiceImpl.java
+++ b/src/main/java/io/boomerang/service/crud/TeamServiceImpl.java
@@ -496,42 +496,44 @@ public class TeamServiceImpl implements TeamService {
     return workflowQuotas;
   }
 
-  @Override
-  public List<TeamEntity> getUsersTeamListing(FlowUserEntity userEntity) {
-  	/* 
-  	 * For the case that flowExternalUrlTeam is configured, always get team list from flowExternalUrlTeam 
-  	 * instead of querying flow_team collection.
-  	 */
-  	if (!flowExternalUrlTeam.isBlank()) {
-      return this.externalTeamService.getExternalTeams(flowExternalUrlTeam);
-  	}
-  	
-  	/*
-  	 * For the case that flowExternalUrlUser is configured, but flowExternalUrlTeam is not configured
-  	 * 1. Get team id list from flowExternalUrlUser
-  	 * 2. query flow_team collection against "higherLevelGroupId"
-  	 */
-  	if (!flowExternalUrlUser.isBlank()) {
-  		 UserProfile profile = boomerangUserService.getInternalUserProfile();
-       List<Team> teams = profile.getTeams();
-       if( teams == null || teams.isEmpty()) {
-      	 return Lists.newArrayList();
-       }
-       List<String> higherLevelGroupIds = teams.stream().map(Team::getId).collect(Collectors.toList());
-       return flowTeamService.findTeamsByHigherLevelGroupIds(higherLevelGroupIds);
-  	}
-  	
-  	/*
-  	 * For the case that both flowExternalUrlUser and flowExternalUrlTeam are not configured
-  	 * 1. Get team id list from flow user entity
-  	 * 2. query flow_team collection against "_id"
-  	 */
-  	List<String> teamIds = userEntity.getFlowTeams();
-  	if(teamIds == null || teamIds.isEmpty()) {
-  		return Lists.newArrayList();
-  	}
-    return flowTeamService.findActiveTeamsByIds(teamIds);
-  }
+	@Override
+	public List<TeamEntity> getUsersTeamListing(FlowUserEntity userEntity) {
+		/*
+		 * For the case that flowExternalUrlTeam is configured, always get team list
+		 * from flowExternalUrlTeam instead of querying flow_team collection.
+		 */
+		if (!flowExternalUrlTeam.isBlank()) {
+			return this.externalTeamService.getExternalTeams(flowExternalUrlTeam);
+		}
+
+		/*
+		 * For the case that flowExternalUrlUser is configured, but flowExternalUrlTeam
+		 * is not configured 
+		 * 1. Get team id list from flowExternalUrlUser 
+		 * 2. query flow_team collection against "higherLevelGroupId"
+		 */
+		if (!flowExternalUrlUser.isBlank()) {
+			UserProfile profile = boomerangUserService.getInternalUserProfile();
+			List<Team> teams = profile.getTeams();
+			if (teams == null || teams.isEmpty()) {
+				return Lists.newArrayList();
+			}
+			List<String> higherLevelGroupIds = teams.stream().map(Team::getId).collect(Collectors.toList());
+			return flowTeamService.findTeamsByHigherLevelGroupIds(higherLevelGroupIds);
+		}
+
+		/*
+		 * For the case that both flowExternalUrlUser and flowExternalUrlTeam are not
+		 * configured 
+		 * 1. Get team id list from flow user entity 
+		 * 2. query flow_team collection against "_id"
+		 */
+		List<String> teamIds = userEntity.getFlowTeams();
+		if (teamIds == null || teamIds.isEmpty()) {
+			return Lists.newArrayList();
+		}
+		return flowTeamService.findActiveTeamsByIds(teamIds);
+	}
 
   @Override
   public List<TeamWorkflowSummary> getUserTeams(FlowUserEntity userEntity) {

--- a/src/main/java/io/boomerang/service/crud/TeamServiceImpl.java
+++ b/src/main/java/io/boomerang/service/crud/TeamServiceImpl.java
@@ -496,8 +496,8 @@ public class TeamServiceImpl implements TeamService {
     return workflowQuotas;
   }
 
-	@Override
-	public List<TeamEntity> getUsersTeamListing(FlowUserEntity userEntity) {
+  @Override
+  public List<TeamEntity> getUsersTeamListing(FlowUserEntity userEntity) {
 		/*
 		 * For the case that flowExternalUrlTeam is configured, always get team list
 		 * from flowExternalUrlTeam instead of querying flow_team collection.
@@ -526,14 +526,14 @@ public class TeamServiceImpl implements TeamService {
 		 * For the case that both flowExternalUrlUser and flowExternalUrlTeam are not
 		 * configured 
 		 * 1. Get team id list from flow user entity 
-		 * 2. query flow_team collection against "_id"
+		 * 2. query flow_teamcollection against "_id"
 		 */
 		List<String> teamIds = userEntity.getFlowTeams();
 		if (teamIds == null || teamIds.isEmpty()) {
 			return Lists.newArrayList();
 		}
 		return flowTeamService.findActiveTeamsByIds(teamIds);
-	}
+  }
 
   @Override
   public List<TeamWorkflowSummary> getUserTeams(FlowUserEntity userEntity) {

--- a/src/main/java/io/boomerang/service/crud/TeamServiceImpl.java
+++ b/src/main/java/io/boomerang/service/crud/TeamServiceImpl.java
@@ -498,24 +498,39 @@ public class TeamServiceImpl implements TeamService {
 
   @Override
   public List<TeamEntity> getUsersTeamListing(FlowUserEntity userEntity) {
-    List<String> teamIds = new LinkedList<>();
-    if (flowExternalUrlUser.isBlank()) {
-      teamIds = userEntity.getFlowTeams();
-    } else {
-      UserProfile profile = boomerangUserService.getInternalUserProfile();
-      List<Team> teams = profile.getTeams();
-      if (teams != null) {
-        teamIds = teams.stream().map(Team::getId).collect(Collectors.toList());
-      }
-    }
-
-    List<TeamEntity> flowTeam = null;
-    if (!flowExternalUrlTeam.isBlank()) {
-      flowTeam = this.externalTeamService.getExternalTeams(flowExternalUrlTeam);
-    } else {
-      flowTeam = flowTeamService.findActiveTeamsByIds(teamIds);
-    }
-    return flowTeam;
+  	/* 
+  	 * For the case that flowExternalUrlTeam is configured, always get team list from flowExternalUrlTeam 
+  	 * instead of querying flow_team collection.
+  	 */
+  	if (!flowExternalUrlTeam.isBlank()) {
+      return this.externalTeamService.getExternalTeams(flowExternalUrlTeam);
+  	}
+  	
+  	/*
+  	 * For the case that flowExternalUrlUser is configured, but flowExternalUrlTeam is not configured
+  	 * 1. Get team id list from flowExternalUrlUser
+  	 * 2. query flow_team collection against "higherLevelGroupId"
+  	 */
+  	if (!flowExternalUrlUser.isBlank()) {
+  		 UserProfile profile = boomerangUserService.getInternalUserProfile();
+       List<Team> teams = profile.getTeams();
+       if( teams == null || teams.isEmpty()) {
+      	 return Lists.newArrayList();
+       }
+       List<String> higherLevelGroupIds = teams.stream().map(Team::getId).collect(Collectors.toList());
+       return flowTeamService.findTeamsByHigherLevelGroupIds(higherLevelGroupIds);
+  	}
+  	
+  	/*
+  	 * For the case that both flowExternalUrlUser and flowExternalUrlTeam are not configured
+  	 * 1. Get team id list from flow user entity
+  	 * 2. query flow_team collection against "_id"
+  	 */
+  	List<String> teamIds = userEntity.getFlowTeams();
+  	if(teamIds == null || teamIds.isEmpty()) {
+  		return Lists.newArrayList();
+  	}
+    return flowTeamService.findActiveTeamsByIds(teamIds);
   }
 
   @Override


### PR DESCRIPTION
Closes #

A defect was found on Core Flow with following configuration: non-admin user always get empty team list
```
flow.externalUrl.team=
flow.externalUrl.user=${users.base.url}/internal/users/user.
```
Based on above configurations and code logic, the team Id list is get from `flow.externalUrl.user` which is mapped to **_higherLevelGroupId_** in **_flow_team_** collection, but the code logic is query against **__id_**.

#### Changelog

**Changed**

- For the case `flow.externalUrl.user` is configured but `flow.externalUrl.team` is not configured.  query  **_flow_team_** collection against **_higherLevelGroupId_** instead of **__id_*.
